### PR TITLE
Fixed runtime peer awareness bug. ...

### DIFF
--- a/src/Network/Legion/StateMachine.hs
+++ b/src/Network/Legion/StateMachine.hs
@@ -260,7 +260,8 @@ handlePeerMessage -- ClusterMerge
         $(logWarn) . pack
           $ "Can't apply incomming cluster action message "
           ++ show msg ++ "because of: " ++ show err
-      Right (newCluster, newMigration) ->
+      Right (newCluster, newMigration) -> do
+        emit . NewPeers . getPeers $ newCluster
         putS nodeState {
             migration = migration `union` newMigration,
             cluster = newCluster


### PR DESCRIPTION
There was a problem where the connection manager part of the
runtime system was not picking up peers that had joined the cluster.
Specifically, if knowledge about a peer was obtained via gossip, instead
of that peer directly joining us, then the connection manager wouldn't
pick it up. This is because the state machine failed inform the runtime
whenever it received a cluster state update from another peer.

We probably need to change the way the runtime system detects changes
in the state; probably by inspecting the state directly instead of have
the state machine communicate directly with the runtime.