### PR TITLE
Use JSON format for node state debugging. ...

### DIFF
--- a/legion.cabal
+++ b/legion.cabal
@@ -48,6 +48,7 @@ library
   -- other-extensions:    
   build-depends:
     Ranged-sets >= 0.3.0 && < 0.4,
+    aeson >= 0.11.2.0 && < 0.12,
     attoparsec >= 0.13.0.1 && < 0.14,
     base >= 4.8 && < 4.9,
     binary >= 0.7.5 && < 0.9,

--- a/src/Network/Legion/ClusterState.hs
+++ b/src/Network/Legion/ClusterState.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {- |
   This module contains the data types related to the distributed cluster state.
 -}
@@ -24,6 +25,7 @@ module Network.Legion.ClusterState (
   heartbeat,
 ) where
 
+import Data.Aeson (ToJSON, toJSON, object, (.=))
 import Data.Binary (Binary)
 import Data.Default.Class (Default(def))
 import Data.Map (Map)
@@ -59,6 +61,14 @@ instance Default ClusterState where
       distribution = D.empty,
              peers = Map.empty
     }
+instance ToJSON ClusterState where
+  toJSON ClusterState {distribution, peers} = object [
+      "distribution" .= distribution,
+      "peers" .= Map.fromList [
+          (show p, show a)
+          | (p, a) <- Map.toList peers
+        ]
+    ]
 
 
 {- |
@@ -75,7 +85,7 @@ newtype ClusterPowerState = ClusterPowerState {
 -}
 newtype ClusterPropState = ClusterPropState {
     unPropState :: PropState UUID ClusterState Peer Update
-  } deriving (Show)
+  } deriving (Show, ToJSON)
 
 
 {- |

--- a/src/Network/Legion/Distribution.hs
+++ b/src/Network/Legion/Distribution.hs
@@ -17,10 +17,12 @@ module Network.Legion.Distribution (
 
 import Prelude hiding (null)
 
+import Data.Aeson (ToJSON, toJSON, object, (.=))
 import Data.Binary (Binary)
 import Data.Function (on)
 import Data.List (sort, sortBy)
 import Data.Set (Set, toList)
+import Data.Text (pack)
 import Data.UUID (UUID)
 import GHC.Generics (Generic)
 import Network.Legion.KeySet (KeySet, member, (\\), null)
@@ -47,6 +49,11 @@ instance Read Peer where
 newtype ParticipationDefaults = D {
     unD :: [(KeySet, Set Peer)]
   } deriving (Show, Binary)
+instance ToJSON ParticipationDefaults where
+  toJSON (D dist) = object [
+      pack (show ks) .= Set.map show peers
+      | (ks, peers) <- dist
+    ]
 
 
 {- |

--- a/src/Network/Legion/Propagation.hs
+++ b/src/Network/Legion/Propagation.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {- |
   This module defines how to propagate a PowerState amoung its participants.
 -}
@@ -30,6 +31,7 @@ module Network.Legion.Propagation (
 
 import Prelude hiding (lookup)
 
+import Data.Aeson (ToJSON, object, (.=), toJSON)
 import Data.Binary (Binary)
 import Data.Default.Class (Default)
 import Data.Map (Map, lookup)
@@ -68,6 +70,16 @@ data PropState o s p d = PropState {
           self :: p,
            now :: Time
   } deriving (Eq, Show)
+instance (Show o, ToJSON s, Show p, Show d) => ToJSON (PropState o s p d) where
+  toJSON PropState {powerState, peerStates, self, now} = object [
+      "powerState" .= powerState,
+      "peerStates" .= Map.fromList [
+          (show p, show s)
+          | (p, s) <- Map.toList peerStates
+        ],
+      "self" .= show self,
+      "now" .= show now
+    ]
 
 
 {- |

--- a/src/Network/Legion/StateMachine.hs
+++ b/src/Network/Legion/StateMachine.hs
@@ -44,14 +44,17 @@ import Control.Monad.Logger (logDebug, logWarn, logError, logInfo,
   MonadLogger)
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Control.Monad.Trans.State (StateT, runStateT, get, put)
+import Data.Aeson (ToJSON, toJSON, object, (.=), encode)
 import Data.Binary (Binary)
+import Data.ByteString.Lazy (toStrict)
 import Data.Conduit (Source, Conduit, ($$), await, awaitForever,
   transPipe, ConduitM, yield, ($=))
 import Data.Default.Class (Default)
 import Data.Map (Map, insert, lookup)
 import Data.Maybe (fromMaybe)
 import Data.Set (member, minView, (\\))
-import Data.Text (pack)
+import Data.Text (pack, unpack)
+import Data.Text.Encoding (decodeUtf8)
 import Data.Time.Clock (getCurrentTime)
 import Data.UUID (UUID)
 import Data.Word (Word64)
@@ -521,7 +524,23 @@ data NodeState i o s = NodeState {
         migration :: KeySet,
            nextId :: MessageId
   }
-  deriving (Show)
+instance (Show i, Show s) => Show (NodeState i o s) where
+  show = unpack . decodeUtf8 . toStrict . encode
+{-
+  The ToJSON instance is mainly for debugging. The Haskell-generated 'Show'
+  instance is very hard to read.
+-}
+instance (Show i, Show s) => ToJSON (NodeState i o s) where
+  toJSON (NodeState self cluster forwarded propStates migration nextId) =
+    object [
+        "self" .= show self,
+        "cluster" .= cluster,
+        -- "forwarded" .= show <$> Map.keys (unF forwarded),
+        "forwarded" .= [show k | k <- Map.keys (unF forwarded)],
+        "propStates" .= show propStates,
+        "migration" .= show migration,
+        "nextId" .= show nextId
+      ]
 
 
 {- | A set of forwarded messages.  -}


### PR DESCRIPTION
Changed `instance Show NodeState` to render JSON instead of the normal
haskell-generated Show. This makes it much easier to work with
node state dumps in the log files.