### PR TITLE
Release completed propagation states from cache. ...

### DIFF
--- a/src/Network/Legion/Distribution.hs
+++ b/src/Network/Legion/Distribution.hs
@@ -141,38 +141,6 @@ rebalanceAction self allPeers (D dist) =
 
     weightOf p = sum [KS.size ks | (ks, ps) <- dist, p `Set.member` ps]
 
---     -- TODO: first figure out if any replicas need re-building.
---     case sortBy (weight `on` snd) (toList dist) of
---       (p, keyspace):remaining | p == peer ->
---         case reverse remaining of
---           [] -> Nothing
---           (target, targetSpace):_ ->
---             let
---                 {- |
---                   Keys that already exist at the target are not eligible
---                   for being moved.
---                 -}
---                 eligibleSpace = keyspace \\ targetSpace
---                 migrationSize = (size keyspace - size targetSpace) `div` 2
---                 migrants = pickMigrants migrationSize eligibleSpace
---             in
---             case migrants of
---               Just keys -> Just (Move target keys)
---               Nothing -> Nothing
---       _ -> Nothing
---   where
---     weight
---       :: KeySet
---       -> KeySet
---       -> Ordering
---     weight = flip compare `on` size
--- 
---     pickMigrants :: Integer -> KeySet -> Maybe KeySet
---     pickMigrants n keyspace =
---       let migrants = take n keyspace in
---       if size migrants > 0
---         then Just migrants
---         else Nothing 
 
 
 {- |

--- a/src/Network/Legion/PartitionKey.hs
+++ b/src/Network/Legion/PartitionKey.hs
@@ -19,9 +19,7 @@ import Data.Ranged (DiscreteOrdered(adjacent, adjacentBelow))
 import Data.Word (Word64)
 
 
-{- |
-  This is how partitions are identified and referenced.
--}
+{- | This is how partitions are identified and referenced. -}
 newtype PartitionKey = K {unkey :: Word256} deriving (Eq, Ord, Show, Bounded)
 
 instance Binary PartitionKey where
@@ -35,9 +33,7 @@ instance DiscreteOrdered PartitionKey where
   adjacentBelow (K k) = if k == minBound then Nothing else Just (K (pred k))
 
 
-{- |
-  Convert a `PartitionKey` into a hex string
--}
+{- | Convert a `PartitionKey` into a hex string. -}
 toHex :: PartitionKey -> String
 toHex (K (Word256 (Word128 a b) (Word128 c d))) =
   concatMap toHex64 [a, b, c, d]
@@ -76,9 +72,7 @@ toHex64 w = fmap (digit . quad) [15, 14..0]
         (True,  True,  True,  True)  -> 'f'
 
 
-{- |
-  Maybe convert a hex string into a partition key
--}
+{- | Maybe convert a hex string into a partition key -}
 fromHex :: String -> Either String PartitionKey
 fromHex str
     | length str > 64 =

--- a/src/Network/Legion/PartitionState.hs
+++ b/src/Network/Legion/PartitionState.hs
@@ -19,6 +19,7 @@ module Network.Legion.PartitionState (
   projParticipants,
   projected,
   infimum,
+  complete,
 ) where
 
 import Data.Binary (Binary)
@@ -178,5 +179,15 @@ projected = P.projected . unPowerState
 -}
 infimum :: PartitionPowerState i s -> s
 infimum = P.infimum . unPowerState
+
+
+{- |
+  Figure out if this propagation state has any work to do. Return 'True' if all
+  known propagation work has been completed. The implication here is that the
+  only way more work can happen is if new deltas are applied, either directly
+  or via a merge.
+-}
+complete :: PartitionPropState i s -> Bool
+complete = P.complete . unPropState
 
 

--- a/src/Network/Legion/PartitionState.hs
+++ b/src/Network/Legion/PartitionState.hs
@@ -22,6 +22,7 @@ module Network.Legion.PartitionState (
   complete,
 ) where
 
+import Data.Aeson (ToJSON)
 import Data.Binary (Binary)
 import Data.Default.Class (Default)
 import Data.Set (Set)
@@ -53,7 +54,7 @@ newtype PartitionPowerState i s = PartitionPowerState {
 -}
 newtype PartitionPropState i s = PartitionPropState {
     unPropState :: PropState PartitionKey s Peer i
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, ToJSON)
 
 
 -- {- |

--- a/src/Network/Legion/PowerState.hs
+++ b/src/Network/Legion/PowerState.hs
@@ -52,7 +52,7 @@ data PowerState o s p d = PowerState {
      deltas :: Map (StateId p) (Delta p d, Set p)
   } deriving (Generic, Show, Eq)
 instance (Binary o, Binary s, Binary p, Binary d) => Binary (PowerState o s p d)
-instance (Show o, ToJSON s, Show p, Show d) => ToJSON (PowerState o s p d) where
+instance (Show o, Show s, Show p, Show d) => ToJSON (PowerState o s p d) where
   toJSON PowerState {origin, infimum, deltas} = object [
       "origin" .= show origin,
       "infimum" .= infimum,
@@ -77,11 +77,11 @@ instance (Eq p) => Eq (Infimum s p) where
   Infimum s1 _ _ == Infimum s2 _ _ = s1 == s2
 instance (Ord p) => Ord (Infimum s p) where
   compare (Infimum s1 _ _) (Infimum s2 _ _) = compare s1 s2
-instance (ToJSON s, Show p) => ToJSON (Infimum s p) where
+instance (Show s, Show p) => ToJSON (Infimum s p) where
   toJSON Infimum {stateId, participants, stateValue} = object [
       "stateId" .= show stateId,
       "participants" .= Set.map show participants,
-      "stateValue" .= stateValue
+      "stateValue" .= show stateValue
     ]
 
 

--- a/src/Network/Legion/Propagation.hs
+++ b/src/Network/Legion/Propagation.hs
@@ -27,6 +27,7 @@ module Network.Legion.Propagation (
   projParticipants,
   projected,
   infimum,
+  complete,
 ) where
 
 import Prelude hiding (lookup)
@@ -376,5 +377,16 @@ projected = PS.projectedValue . unPowerState
 -}
 infimum :: PropPowerState o s p d -> s
 infimum = PS.infimumValue . unPowerState
+
+
+{- |
+  Figure out if this propagation state has any work to do. Return 'True' if all
+  known propagation work has been completed. The implication here is that the
+  only way more work can happen is if new deltas are applied, either directly
+  or via a merge.
+-}
+complete :: (Ord p) => PropState o s p d -> Bool
+complete PropState {powerState, peerStates} =
+  Map.null peerStates && Set.null (divergent powerState)
 
 

--- a/src/Network/Legion/Propagation.hs
+++ b/src/Network/Legion/Propagation.hs
@@ -71,7 +71,7 @@ data PropState o s p d = PropState {
           self :: p,
            now :: Time
   } deriving (Eq, Show)
-instance (Show o, ToJSON s, Show p, Show d) => ToJSON (PropState o s p d) where
+instance (Show o, Show s, Show p, Show d) => ToJSON (PropState o s p d) where
   toJSON PropState {powerState, peerStates, self, now} = object [
       "powerState" .= powerState,
       "peerStates" .= Map.fromList [

--- a/src/Network/Legion/Runtime.hs
+++ b/src/Network/Legion/Runtime.hs
@@ -182,7 +182,7 @@ startPeerListener LegionarySettings {peerBindAddr} =
             let runSocket =
                   sourceSocket conn
                   =$= conduitDecode
-                  $$  msgSink
+                  $$ msgSink
             void
               . lift
               . forkIO

--- a/src/Network/Legion/StateMachine.hs
+++ b/src/Network/Legion/StateMachine.hs
@@ -126,6 +126,7 @@ handleMessage l msg = do
           $(logWarn) . pack
             $ "Dropping message from unknown peer: " ++ show source
     R ((key, request), respond) ->
+      {- TODO distribute requests evenly accross the participating peers. -}
       case minView (C.findPartition key cluster) of
         Nothing ->
           $(logError) . pack
@@ -535,7 +536,6 @@ instance (Show i, Show s) => ToJSON (NodeState i o s) where
     object [
         "self" .= show self,
         "cluster" .= cluster,
-        -- "forwarded" .= show <$> Map.keys (unF forwarded),
         "forwarded" .= [show k | k <- Map.keys (unF forwarded)],
         "propStates" .= show propStates,
         "migration" .= show migration,

--- a/src/Network/Legion/StateMachine.hs
+++ b/src/Network/Legion/StateMachine.hs
@@ -535,7 +535,7 @@ instance (Show i, Show s) => ToJSON (NodeState i o s) where
         "self" .= show self,
         "cluster" .= cluster,
         "forwarded" .= [show k | k <- Map.keys (unF forwarded)],
-        "propStates" .= show propStates,
+        "propStates" .= Map.mapKeys show propStates,
         "migration" .= show migration,
         "nextId" .= show nextId
       ]

--- a/src/Network/Legion/StateMachine.hs
+++ b/src/Network/Legion/StateMachine.hs
@@ -159,8 +159,6 @@ handlePeerMessage -- PartitionMerge
       (getStateL persistence self cluster key)
       return
       (lookup key propStates)
-    let
-      owners = C.findPartition key cluster
     case P.mergeEither source ps propState of
       Left err ->
         $(logWarn) . pack
@@ -174,7 +172,7 @@ handlePeerMessage -- PartitionMerge
               else Nothing
           )
         putS nodeState {
-            propStates = if newPropState == P.new key self owners
+            propStates = if P.complete newPropState
               then Map.delete key propStates
               else insert key newPropState propStates
           }
@@ -386,7 +384,7 @@ migrate Legionary{persistence} = do
 -}
 propagate :: (LegionConstraints i o s) => StateM i o s ()
 propagate = do
-    ns@NodeState {cluster, propStates, self} <- getS
+    ns@NodeState {cluster, propStates} <- getS
     let (peers, ps, cluster2) = C.actions cluster
     $(logDebug) . pack $ "Cluster Actions: " ++ show (peers, ps)
     mapM_ (doClusterAction ps) (Set.toList peers)
@@ -396,7 +394,7 @@ propagate = do
         propStates = Map.fromAscList [
             (k, p)
             | (k, p) <- propStates2
-            , p /= P.initProp self (P.getPowerState p)
+            , not (P.complete p)
           ]
       }
   where


### PR DESCRIPTION
Fixed a bug where we were not releasing partition propagation states from
the node state even though all propagation work had been completed. The
reason was because we were using a completely wrong mechanism to check
if the propagation was "complete".